### PR TITLE
💾 Added maximum lengths to combo titles and notes

### DIFF
--- a/ClientApp/src/pages/EditCombo.jsx
+++ b/ClientApp/src/pages/EditCombo.jsx
@@ -408,6 +408,7 @@ export function EditCombo() {
               type="text"
               placeholder="eg. Down-throw bair"
               value={comboToEdit.title}
+              maxLength={128}
               onChange={handleFieldChange}
               required
             />
@@ -692,6 +693,7 @@ export function EditCombo() {
                 placeholder="Additional notes"
                 id="notes"
                 value={comboToEdit.notes}
+                maxLength={512}
                 onChange={handleFieldChange}
               />
               {errorMessage && (

--- a/Migrations/20200811155437_ComboAnnotations.Designer.cs
+++ b/Migrations/20200811155437_ComboAnnotations.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Smash_Combos.Models;
@@ -9,9 +10,10 @@ using Smash_Combos.Models;
 namespace Smash_Combos.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20200811155437_ComboAnnotations")]
+    partial class ComboAnnotations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20200811155437_ComboAnnotations.cs
+++ b/Migrations/20200811155437_ComboAnnotations.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Smash_Combos.Migrations
+{
+    public partial class ComboAnnotations : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Title",
+                table: "Combos",
+                maxLength: 128,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Notes",
+                table: "Combos",
+                maxLength: 512,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Title",
+                table: "Combos",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldMaxLength: 128);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Notes",
+                table: "Combos",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldMaxLength: 512,
+                oldNullable: true);
+        }
+    }
+}

--- a/Models/Combo.cs
+++ b/Models/Combo.cs
@@ -18,6 +18,7 @@ namespace Smash_Combos.Models
         public DateTime DatePosted { get; private set; } = DateTime.Now;
 
         [Required]
+        [MaxLength(128)]
         public string Title { get; set; }
 
         [Required]
@@ -41,6 +42,7 @@ namespace Smash_Combos.Models
         [Required]
         public int Damage { get; set; }
 
+        [MaxLength(512)]
         public string Notes { get; set; }
 
         public List<Comment> Comments { get; private set; }


### PR DESCRIPTION
I saw your list in the discord and to try out this 'contributing' thing I figured I'd add a max length to combo titles and notes. I chose the values after testing it out a bit, I think 128 chars for the Title and 512 chars for Notes should be enough to get all the information one would need across.