### PR TITLE
💾Added backend logic for Infractions & Reports, Moved User/Login Logic to the Core

### DIFF
--- a/Api/Controllers/InfractionsController.cs
+++ b/Api/Controllers/InfractionsController.cs
@@ -37,7 +37,7 @@ namespace Smash_Combos.Controllers
 
         // GET api/<InfractionsController>/5
         [HttpGet("{id}")]
-        public async Task<ActionResult<GetInfractionResponse>> GetInfraction(int id)
+        public async Task<ActionResult<GetInfractionResponse>> GetInfraction([FromRoute] int id)
         {
             var response = await _mediator.Send(new GetInfractionRequest { InfractionId = id });
             if (response == null)
@@ -49,9 +49,9 @@ namespace Smash_Combos.Controllers
         // POST api/<InfractionsController>
         [HttpPost]
         [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
-        public async Task<ActionResult<PostInfractionResponse>> PostInfraction([FromBody] Infraction infraction)
+        public async Task<ActionResult<PostInfractionResponse>> PostInfraction([FromBody] PostInfractionRequest postInfractionRequest)
         {
-            var response = await _mediator.Send(new PostInfractionRequest { Infraction = infraction });
+            var response = await _mediator.Send(postInfractionRequest);
 
             // Return a response that indicates the object was created (status code `201`) and some additional headers with details of the newly created object.
             return CreatedAtAction("GetInfraction", new { id = response.Id }, response);
@@ -60,14 +60,14 @@ namespace Smash_Combos.Controllers
         // PUT api/<InfractionsController>/5
         [HttpPut("{id}")]
         [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
-        public async Task<ActionResult<PutInfractionResponse>> PutInfraction(int id, [FromBody] Infraction infraction)
+        public async Task<ActionResult<PutInfractionResponse>> PutInfraction([FromRoute] int id, [FromBody] PutInfractionRequest putInfractionRequest)
         {
-            if (id != infraction.Id) // If the ID in the URL does not match the ID in the supplied request body, return a bad request
+            if (id != putInfractionRequest.Id) // If the ID in the URL does not match the ID in the supplied request body, return a bad request
                 return BadRequest();
 
             try
             {
-                var response = await _mediator.Send(new PutInfractionRequest { Infraction = infraction });
+                var response = await _mediator.Send(putInfractionRequest);
 
                 if (response.Success)
                     return Ok(response.Infraction); // Return the updated infraction.

--- a/Api/Controllers/InfractionsController.cs
+++ b/Api/Controllers/InfractionsController.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Smash_Combos.Core.Cqrs.Infractions.DeleteInfraction;
+using Smash_Combos.Core.Cqrs.Infractions.GetInfraction;
+using Smash_Combos.Core.Cqrs.Infractions.GetInfractions;
+using Smash_Combos.Core.Cqrs.Infractions.PostInfraction;
+using Smash_Combos.Core.Cqrs.Infractions.PutInfraction;
+using Smash_Combos.Domain.Models;
+
+namespace Smash_Combos.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class InfractionsController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+
+        public InfractionsController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        // GET: api/<InfractionsController>
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<GetInfractionsResponse>>> GetInfractions()
+        {
+            var response = await _mediator.Send(new GetInfractionsRequest());
+            return Ok(response);
+        }
+
+        // GET api/<InfractionsController>/5
+        [HttpGet("{id}")]
+        public async Task<ActionResult<GetInfractionResponse>> GetInfraction(int id)
+        {
+            var response = await _mediator.Send(new GetInfractionRequest { InfractionId = id });
+            if (response == null)
+                return NotFound();
+
+            return Ok(response);
+        }
+
+        // POST api/<InfractionsController>
+        [HttpPost]
+        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+        public async Task<ActionResult<PostInfractionResponse>> PostInfraction([FromBody] Infraction infraction)
+        {
+            var response = await _mediator.Send(new PostInfractionRequest { Infraction = infraction });
+
+            // Return a response that indicates the object was created (status code `201`) and some additional headers with details of the newly created object.
+            return CreatedAtAction("GetInfraction", new { id = response.Id }, response);
+        }
+
+        // PUT api/<InfractionsController>/5
+        [HttpPut("{id}")]
+        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+        public async Task<ActionResult<PutInfractionResponse>> PutInfraction(int id, [FromBody] Infraction infraction)
+        {
+            if (id != infraction.Id) // If the ID in the URL does not match the ID in the supplied request body, return a bad request
+                return BadRequest();
+
+            try
+            {
+                var response = await _mediator.Send(new PutInfractionRequest { Infraction = infraction });
+
+                if (response.Success)
+                    return Ok(response.Infraction); // Return the updated infraction.
+                else if (response.Infraction == null)
+                    return NotFound();
+                else
+                    return StatusCode(500); // The infraction was found, but couldn't be updated -> something went wrong. How should we handle this?
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                throw; // Should we throw the exception here or deal with it otherwise?
+            }
+        }
+
+        // DELETE api/<InfractionsController>/5
+        [HttpDelete("{id}")]
+        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+        public async Task<ActionResult> DeleteInfraction(int id)
+        {
+            var response = await _mediator.Send(new DeleteInfractionRequest { InfractionId = id, UserId = GetCurrentUserId() });
+
+            if (response.Infraction == null) // There wasn't an infraction with that id so return a `404` not found
+                return NotFound();
+
+            return Ok(response.Infraction); // Send back a copy of the deleted data.
+        }
+
+        private int GetCurrentUserId()
+        {
+            // Get the User Id from the claim and then parse it as an integer.
+            return int.Parse(User.Claims.FirstOrDefault(claim => claim.Type == "Id").Value);
+        }
+    }
+}

--- a/Api/Controllers/ReportsController.cs
+++ b/Api/Controllers/ReportsController.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.CodeAnalysis;
+using Microsoft.EntityFrameworkCore;
+using Smash_Combos.Core.Cqrs.Reports.DeleteReport;
+using Smash_Combos.Core.Cqrs.Reports.GetReport;
+using Smash_Combos.Core.Cqrs.Reports.GetReports;
+using Smash_Combos.Core.Cqrs.Reports.PostComboReport;
+using Smash_Combos.Core.Cqrs.Reports.PostCommentReport;
+using Smash_Combos.Core.Cqrs.Reports.PutReport;
+using Smash_Combos.Domain.Models;
+
+// For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
+
+namespace Smash_Combos.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class ReportsController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+
+        public ReportsController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        // GET: api/<ReportsController>
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<GetReportsResponse>>> GetReports()
+        {
+            var response = await _mediator.Send(new GetReportsRequest());
+            return Ok(response);
+        }
+
+        // GET api/<ReportsController>/5
+        [HttpGet("{id}")]
+        public async Task<ActionResult<GetReportResponse>> GetReport([FromRoute] int id)
+        {
+            var response = await _mediator.Send(new GetReportRequest { ReportId = id });
+            if (response == null)
+                return NotFound();
+
+            return Ok(response);
+        }
+
+        // POST api/<ReportsControler>/combo/5
+        [HttpPost("combo/{comboId}")]
+        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+        public async Task<ActionResult<PostComboReportResponse>> PostComboReport([FromRoute] int comboId, [FromBody] PostComboReportRequest postComboReportRequest)
+        {
+            if (comboId != postComboReportRequest.ComboId)
+                return BadRequest();
+
+            var response = await _mediator.Send(postComboReportRequest);
+
+            if (response.User == null || response.Reporter == null)
+                return NotFound();
+
+            // Return a response that indicates the object was created (status code `201`) and some additional headers with details of the newly created object.
+            return CreatedAtAction("GetReport", new { id = response.Id }, response);
+        }
+
+        // POST api/<ReportsControler>/comment/5
+        [HttpPost("comment/{commentId}")]
+        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+        public async Task<ActionResult<PostCommentReportResponse>> PostCommentReport([FromRoute] int commentId, [FromBody] PostCommentReportRequest postCommentReportRequest)
+        {
+            if (commentId != postCommentReportRequest.CommentId)
+                return BadRequest();
+
+            var response = await _mediator.Send(postCommentReportRequest);
+
+            if (response.User == null || response.Reporter == null)
+                return NotFound();
+
+            // Return a response that indicates the object was created (status code `201`) and some additional headers with details of the newly created object.
+            return CreatedAtAction("GetReport", new { id = response.Id }, response);
+        }
+
+        // PUT api/<ReportsController>/5
+        [HttpPut("{id}")]
+        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+        public async Task<ActionResult<PutReportResponse>> PutReport([FromRoute] int id, [FromBody] PutReportRequest putReportRequest)
+        {
+            if (id != putReportRequest.Id) // If the ID in the URL does not match the ID in the supplied request body, return a bad request
+                return BadRequest();
+
+            try
+            {
+                var response = await _mediator.Send(putReportRequest);
+
+                if (response.Success)
+                    return Ok(response.Report); // Return the updated report.
+                else if (response.Report == null)
+                    return NotFound();
+                else
+                    return StatusCode(500); // The report was found, but couldn't be updated -> something went wrong. How should we handle this?
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                throw; // Should we throw the exception here or deal with it otherwise?
+            }
+        }
+
+        // DELETE api/<ReportsController>/5
+        [HttpDelete("{id}")]
+        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+        public async Task<ActionResult> DeleteReport([FromRoute] int id)
+        {
+            var response = await _mediator.Send(new DeleteReportRequest { ReportId = id, UserId = GetCurrentUserId() });
+
+            if (response.Report == null) // There wasn't a report with that id so return a `404` not found
+                return NotFound();
+
+            return Ok(response.Report); // Send back a copy of the deleted data.
+        }
+
+        private int GetCurrentUserId()
+        {
+            // Get the User Id from the claim and then parse it as an integer.
+            return int.Parse(User.Claims.FirstOrDefault(claim => claim.Type == "Id").Value);
+        }
+    }
+}

--- a/Api/Controllers/UsersController.cs
+++ b/Api/Controllers/UsersController.cs
@@ -10,6 +10,9 @@ using MediatR;
 using Smash_Combos.Core.Cqrs.Users.GetUser;
 using Smash_Combos.Core.Cqrs.Users.GetUsers;
 using Smash_Combos.Core.Cqrs.Users.PostUser;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Smash_Combos.Core.Cqrs.Users.UnbanUser;
 
 namespace Smash_Combos.Controllers
 {
@@ -102,6 +105,24 @@ namespace Smash_Combos.Controllers
             // Return a response that indicates the object was created (status code `201`) and some additional
             // headers with details of the newly created object.
             return CreatedAtAction("GetUser", new { id = user.Id }, response.User);
+        }
+
+        [HttpPut("unban/{id}")]
+        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+        public async Task<ActionResult<UnbanUserResponse>> UnbanUser([FromRoute] int id)
+        {
+            var response = await _mediator.Send(new UnbanUserRequest { UserId = id, ModeratorId = GetCurrentUserId() });
+
+            if(response == null)
+                return BadRequest();
+
+            return Ok(response);
+        }
+
+        private int GetCurrentUserId()
+        {
+            // Get the User Id from the claim and then parse it as an integer.
+            return int.Parse(User.Claims.FirstOrDefault(claim => claim.Type == "Id").Value);
         }
     }
 }

--- a/Smash_Combos.Core/Cqrs/Infractions/DeleteInfraction/DeleteInfractionProfile.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/DeleteInfraction/DeleteInfractionProfile.cs
@@ -1,0 +1,17 @@
+﻿using AutoMapper;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.DeleteInfraction
+{
+    public class DeleteInfractionProfile : Profile
+    {
+        public DeleteInfractionProfile()
+        {
+            CreateMap<Infraction, InfractionDto>();
+            CreateMap<User, UserDto>();
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/DeleteInfraction/DeleteInfractionRequest.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/DeleteInfraction/DeleteInfractionRequest.cs
@@ -1,0 +1,13 @@
+﻿using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.DeleteInfraction
+{
+    public class DeleteInfractionRequest : IRequest<DeleteInfractionResponse>
+    {
+        public int InfractionId { get; set; }
+        public int UserId { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/DeleteInfraction/DeleteInfractionRequestHandler.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/DeleteInfraction/DeleteInfractionRequestHandler.cs
@@ -1,0 +1,39 @@
+﻿using AutoMapper;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Smash_Combos.Core.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.DeleteInfraction
+{
+    public class DeleteInfractionRequestHandler : IRequestHandler<DeleteInfractionRequest, DeleteInfractionResponse>
+    {
+        private readonly IDbContext _dbContext;
+        private readonly IMapper _mapper;
+
+        public DeleteInfractionRequestHandler(IDbContext dbContext, IMapper mapper)
+        {
+            _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        }
+
+        public async Task<DeleteInfractionResponse> Handle(DeleteInfractionRequest request, CancellationToken cancellationToken)
+        {
+            var infraction = await _dbContext.Infractions.Where(infraction => infraction.Id == request.InfractionId && infraction.User.Id == request.UserId).FirstOrDefaultAsync();
+            if (infraction == null)
+            {
+                return new DeleteInfractionResponse { Success = false };
+            }
+
+            _dbContext.Infractions.Remove(infraction);
+            await _dbContext.SaveChangesAsync(CancellationToken.None);
+
+            return new DeleteInfractionResponse { Success = true, Infraction = _mapper.Map<InfractionDto>(infraction) };
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/DeleteInfraction/DeleteInfractionRequestHandler.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/DeleteInfraction/DeleteInfractionRequestHandler.cs
@@ -24,7 +24,11 @@ namespace Smash_Combos.Core.Cqrs.Infractions.DeleteInfraction
 
         public async Task<DeleteInfractionResponse> Handle(DeleteInfractionRequest request, CancellationToken cancellationToken)
         {
-            var infraction = await _dbContext.Infractions.Where(infraction => infraction.Id == request.InfractionId && infraction.User.Id == request.UserId).FirstOrDefaultAsync();
+            var infraction = await _dbContext.Infractions
+                                .Include(infraction => infraction.User)
+                                .Include(infraction => infraction.Moderator)
+                                .Where(infraction => infraction.Id == request.InfractionId && infraction.User.Id == request.UserId)
+                                .FirstOrDefaultAsync();
             if (infraction == null)
             {
                 return new DeleteInfractionResponse { Success = false };

--- a/Smash_Combos.Core/Cqrs/Infractions/DeleteInfraction/DeleteInfractionResponse.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/DeleteInfraction/DeleteInfractionResponse.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.DeleteInfraction
+{
+    public class DeleteInfractionResponse
+    {
+        public bool Success { get; set; }
+        public InfractionDto Infraction { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/DeleteInfraction/InfractionDto.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/DeleteInfraction/InfractionDto.cs
@@ -1,0 +1,28 @@
+﻿using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.DeleteInfraction
+{
+    public class InfractionDto
+    {
+        public int Id { get; set; }
+
+        public UserDto User { get; set; }
+
+        public UserDto Moderator { get; set; }
+
+        public int? BanDuration { get; set; }
+
+        public DateTime? BanLiftDate { get; set; }
+
+        public int? Points { get; private set; }
+
+        public InfractionCategory Category { get; private set; }
+
+        public string Body { get; set; }
+
+        public DateTime DateInfracted { get; private set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/DeleteInfraction/InfractionDto.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/DeleteInfraction/InfractionDto.cs
@@ -19,10 +19,10 @@ namespace Smash_Combos.Core.Cqrs.Infractions.DeleteInfraction
 
         public int? Points { get; private set; }
 
-        public InfractionCategory Category { get; private set; }
+        public InfractionCategory Category { get; set; }
 
         public string Body { get; set; }
 
-        public DateTime DateInfracted { get; private set; }
+        public DateTime DateInfracted { get; set; }
     }
 }

--- a/Smash_Combos.Core/Cqrs/Infractions/DeleteInfraction/UserDto.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/DeleteInfraction/UserDto.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.DeleteInfraction
+{
+    public class UserDto
+    {
+        public string DisplayName { get; set; }
+        public string Email { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/GetInfraction/GetInfractionProfile.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/GetInfraction/GetInfractionProfile.cs
@@ -1,0 +1,17 @@
+﻿using AutoMapper;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.GetInfraction
+{
+    public class GetInfractionProfile : Profile
+    {
+        public GetInfractionProfile()
+        {
+            CreateMap<Infraction, GetInfractionResponse>();
+            CreateMap<User, UserDto>();
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/GetInfraction/GetInfractionRequest.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/GetInfraction/GetInfractionRequest.cs
@@ -1,0 +1,12 @@
+﻿using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.GetInfraction
+{
+    public class GetInfractionRequest : IRequest<GetInfractionResponse>
+    {
+        public int InfractionId { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/GetInfraction/GetInfractionRequestHandler.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/GetInfraction/GetInfractionRequestHandler.cs
@@ -1,0 +1,39 @@
+﻿using AutoMapper;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Smash_Combos.Core.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.GetInfraction
+{
+    public class GetInfractionRequestHandler : IRequestHandler<GetInfractionRequest, GetInfractionResponse>
+    {
+        private readonly IDbContext _dbContext;
+        private readonly IMapper _mapper;
+
+        public GetInfractionRequestHandler(IDbContext dbContext, IMapper mapper)
+        {
+            _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        }
+
+        public async Task<GetInfractionResponse> Handle(GetInfractionRequest request, CancellationToken cancellationToken)
+        {
+            var infraction = await _dbContext.Infractions
+                .Where(infraction => infraction.Id == request.InfractionId)
+                .Include(infraction => infraction.User)
+                .Include(infraction => infraction.Moderator)
+                .FirstOrDefaultAsync();
+
+            if (infraction == null)
+                return null;
+
+            return _mapper.Map<GetInfractionResponse>(infraction);
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/GetInfraction/GetInfractionResponse.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/GetInfraction/GetInfractionResponse.cs
@@ -1,0 +1,28 @@
+﻿using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.GetInfraction
+{
+    public class GetInfractionResponse
+    {
+        public int Id { get; set; }
+
+        public UserDto User { get; set; }
+
+        public UserDto Moderator { get; set; }
+
+        public int? BanDuration { get; set; }
+
+        public DateTime? BanLiftDate { get; set; }
+
+        public int? Points { get; private set; }
+
+        public InfractionCategory Category { get; private set; }
+
+        public string Body { get; set; }
+
+        public DateTime DateInfracted { get; private set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/GetInfraction/UserDto.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/GetInfraction/UserDto.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.GetInfraction
+{
+    public class UserDto
+    {
+        public string DisplayName { get; set; }
+        public string Email { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/GetInfractions/GetInfractionsProfile.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/GetInfractions/GetInfractionsProfile.cs
@@ -1,0 +1,17 @@
+﻿using AutoMapper;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.GetInfractions
+{
+    public class GetInfractionsProfile : Profile
+    {
+        public GetInfractionsProfile()
+        {
+            CreateMap<Infraction, GetInfractionsResponse>();
+            CreateMap<User, UserDto>();
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/GetInfractions/GetInfractionsRequest.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/GetInfractions/GetInfractionsRequest.cs
@@ -1,0 +1,11 @@
+﻿using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.GetInfractions
+{
+    public class GetInfractionsRequest : IRequest<IEnumerable<GetInfractionsResponse>>
+    {
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/GetInfractions/GetInfractionsRequestHandler.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/GetInfractions/GetInfractionsRequestHandler.cs
@@ -1,0 +1,34 @@
+﻿using AutoMapper;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Smash_Combos.Core.Services;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.GetInfractions
+{
+    public class GetInfractionsRequestHandler : IRequestHandler<GetInfractionsRequest, IEnumerable<GetInfractionsResponse>>
+    {
+        private readonly IDbContext _dbContext;
+        private readonly IMapper _mapper;
+
+        public GetInfractionsRequestHandler(IDbContext dbContext, IMapper mapper)
+        {
+            _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        }
+
+        public async Task<IEnumerable<GetInfractionsResponse>> Handle(GetInfractionsRequest request, CancellationToken cancellationToken)
+        {
+            var infractions = await _dbContext.Infractions
+                .Include(infraction => infraction.User)
+                .Include(infraction => infraction.Moderator)
+                .ToListAsync();
+
+            return _mapper.Map<IEnumerable<GetInfractionsResponse>>(infractions);
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/GetInfractions/GetInfractionsResponse.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/GetInfractions/GetInfractionsResponse.cs
@@ -1,0 +1,28 @@
+﻿using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.GetInfractions
+{
+    public class GetInfractionsResponse
+    {
+        public int Id { get; set; }
+
+        public UserDto User { get; set; }
+
+        public UserDto Moderator { get; set; }
+
+        public int? BanDuration { get; set; }
+
+        public DateTime? BanLiftDate { get; set; }
+
+        public int? Points { get; private set; }
+
+        public InfractionCategory Category { get; private set; }
+
+        public string Body { get; set; }
+
+        public DateTime DateInfracted { get; private set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/GetInfractions/UserDto.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/GetInfractions/UserDto.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.GetInfractions
+{
+    public class UserDto
+    {
+        public string DisplayName { get; set; }
+        public string Email { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/PostInfraction/PostInfractionProfile.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/PostInfraction/PostInfractionProfile.cs
@@ -1,0 +1,17 @@
+﻿using AutoMapper;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.PostInfraction
+{
+    public class PostInfractionProfile : Profile
+    {
+        public PostInfractionProfile()
+        {
+            CreateMap<Infraction, PostInfractionResponse>();
+            CreateMap<User, UserDto>();
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/PostInfraction/PostInfractionRequest.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/PostInfraction/PostInfractionRequest.cs
@@ -8,7 +8,17 @@ namespace Smash_Combos.Core.Cqrs.Infractions.PostInfraction
 {
     public class PostInfractionRequest : IRequest<PostInfractionResponse>
     {
-        public Infraction Infraction { get; set; }
         public int UserId { get; set; }
+
+        public int ModeratorId { get; set; }
+
+        public int? BanDuration { get; set; }
+
+        public int? Points { get; set; }
+
+        public InfractionCategory Category { get; set; }
+
+        public string Body { get; set; }
+
     }
 }

--- a/Smash_Combos.Core/Cqrs/Infractions/PostInfraction/PostInfractionRequest.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/PostInfraction/PostInfractionRequest.cs
@@ -1,0 +1,14 @@
+﻿using MediatR;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.PostInfraction
+{
+    public class PostInfractionRequest : IRequest<PostInfractionResponse>
+    {
+        public Infraction Infraction { get; set; }
+        public int UserId { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/PostInfraction/PostInfractionRequestHandler.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/PostInfraction/PostInfractionRequestHandler.cs
@@ -38,7 +38,7 @@ namespace Smash_Combos.Core.Cqrs.Infractions.PostInfraction
                 Body = request.Body,
                 BanDuration = request.BanDuration,
                 Category = request.Category,
-                Points = request.Points
+                Points = DeterminePoints(request)
             };
             _dbContext.Infractions.Add(infraction);
 
@@ -48,6 +48,21 @@ namespace Smash_Combos.Core.Cqrs.Infractions.PostInfraction
             await _dbContext.SaveChangesAsync(CancellationToken.None);
 
             return _mapper.Map<PostInfractionResponse>(infraction);
+        }
+
+        private int? DeterminePoints(PostInfractionRequest request)
+        {
+            if (request.Points != null)
+                return request.Points;
+
+            return request.Category switch
+            {
+                InfractionCategory.Spam => 1,
+                InfractionCategory.Inappropriate => 1,
+                InfractionCategory.Harassment => 2,
+                InfractionCategory.Other => request.Points,
+                _ => null,
+            };
         }
     }
 }

--- a/Smash_Combos.Core/Cqrs/Infractions/PostInfraction/PostInfractionRequestHandler.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/PostInfraction/PostInfractionRequestHandler.cs
@@ -1,0 +1,36 @@
+﻿using AutoMapper;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Smash_Combos.Core.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.PostInfraction
+{
+    public class PostInfractionRequestHandler : IRequestHandler<PostInfractionRequest, PostInfractionResponse>
+    {
+        private readonly IDbContext _dbContext;
+        private readonly IMapper _mapper;
+
+        public PostInfractionRequestHandler(IDbContext dbContext, IMapper mapper)
+        {
+            _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        }
+
+        public async Task<PostInfractionResponse> Handle(PostInfractionRequest request, CancellationToken cancellationToken)
+        {
+            var user = await _dbContext.Users.Where(user => user.Id == request.UserId).FirstOrDefaultAsync();
+            request.Infraction.User = user;
+
+            _dbContext.Infractions.Add(request.Infraction);
+            await _dbContext.SaveChangesAsync(CancellationToken.None);
+
+            return _mapper.Map<PostInfractionResponse>(request.Infraction);
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/PostInfraction/PostInfractionRequestHandler.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/PostInfraction/PostInfractionRequestHandler.cs
@@ -2,6 +2,7 @@
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Smash_Combos.Core.Services;
+using Smash_Combos.Domain.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -25,12 +26,28 @@ namespace Smash_Combos.Core.Cqrs.Infractions.PostInfraction
         public async Task<PostInfractionResponse> Handle(PostInfractionRequest request, CancellationToken cancellationToken)
         {
             var user = await _dbContext.Users.Where(user => user.Id == request.UserId).FirstOrDefaultAsync();
-            request.Infraction.User = user;
+            var moderator = await _dbContext.Users.Where(user => user.Id == request.ModeratorId).FirstOrDefaultAsync();
 
-            _dbContext.Infractions.Add(request.Infraction);
+            if (user == null || moderator == null)
+                return new PostInfractionResponse { User = null, Moderator = null };
+
+            var infraction = new Infraction
+            {
+                User = user,
+                Moderator = moderator,
+                Body = request.Body,
+                BanDuration = request.BanDuration,
+                Category = request.Category,
+                Points = request.Points
+            };
+            _dbContext.Infractions.Add(infraction);
+
+            user.Infractions.Add(infraction);
+            _dbContext.Entry(user).State = EntityState.Modified;
+
             await _dbContext.SaveChangesAsync(CancellationToken.None);
 
-            return _mapper.Map<PostInfractionResponse>(request.Infraction);
+            return _mapper.Map<PostInfractionResponse>(infraction);
         }
     }
 }

--- a/Smash_Combos.Core/Cqrs/Infractions/PostInfraction/PostInfractionResponse.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/PostInfraction/PostInfractionResponse.cs
@@ -1,0 +1,28 @@
+﻿using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.PostInfraction
+{
+    public class PostInfractionResponse
+    {
+        public int Id { get; set; }
+        
+        public UserDto User { get; set; }
+
+        public UserDto Moderator { get; set; }
+
+        public int? BanDuration { get; set; }
+
+        public DateTime? BanLiftDate { get; set; }
+
+        public int? Points { get; private set; }
+
+        public InfractionCategory Category { get; private set; }
+
+        public string Body { get; set; }
+
+        public DateTime DateInfracted { get; private set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/PostInfraction/UserDto.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/PostInfraction/UserDto.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.PostInfraction
+{
+    public class UserDto
+    {
+        public string DisplayName { get; set; }
+        public string Email { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/PutInfraction/InfractionDto.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/PutInfraction/InfractionDto.cs
@@ -1,0 +1,28 @@
+﻿using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.PutInfraction
+{
+    public class InfractionDto
+    {
+        public int Id { get; set; }
+
+        public UserDto User { get; set; }
+
+        public UserDto Moderator { get; set; }
+
+        public int? BanDuration { get; set; }
+
+        public DateTime? BanLiftDate { get; set; }
+
+        public int? Points { get; private set; }
+
+        public InfractionCategory Category { get; private set; }
+
+        public string Body { get; set; }
+
+        public DateTime DateInfracted { get; private set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/PutInfraction/InfractionDto.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/PutInfraction/InfractionDto.cs
@@ -17,9 +17,9 @@ namespace Smash_Combos.Core.Cqrs.Infractions.PutInfraction
 
         public DateTime? BanLiftDate { get; set; }
 
-        public int? Points { get; private set; }
+        public int? Points { get; set; }
 
-        public InfractionCategory Category { get; private set; }
+        public InfractionCategory Category { get; set; }
 
         public string Body { get; set; }
 

--- a/Smash_Combos.Core/Cqrs/Infractions/PutInfraction/PutInfractionProfile.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/PutInfraction/PutInfractionProfile.cs
@@ -10,7 +10,7 @@ namespace Smash_Combos.Core.Cqrs.Infractions.PutInfraction
     {
         public PutInfractionProfile()
         {
-            CreateMap<Infraction, PutInfractionResponse>();
+            CreateMap<Infraction, InfractionDto>();
             CreateMap<User, UserDto>();
         }
     }

--- a/Smash_Combos.Core/Cqrs/Infractions/PutInfraction/PutInfractionProfile.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/PutInfraction/PutInfractionProfile.cs
@@ -1,0 +1,17 @@
+﻿using AutoMapper;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.PutInfraction
+{
+    public class PutInfractionProfile : Profile
+    {
+        public PutInfractionProfile()
+        {
+            CreateMap<Infraction, PutInfractionResponse>();
+            CreateMap<User, UserDto>();
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/PutInfraction/PutInfractionRequest.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/PutInfraction/PutInfractionRequest.cs
@@ -8,8 +8,11 @@ namespace Smash_Combos.Core.Cqrs.Infractions.PutInfraction
 {
     public class PutInfractionRequest : IRequest<PutInfractionResponse>
     {
-        public int InfractionId { get; set; }
-        public int UserId { get; set; }
-        public Infraction Infraction { get; set; }
+        public int Id { get; set; }
+        public int? BanDuration { get; set; }
+        public int? Points { get; set; }
+        public InfractionCategory Category { get; set; }
+        public string Body { get; set; }
+        public bool LiftBan { get; set; }
     }
 }

--- a/Smash_Combos.Core/Cqrs/Infractions/PutInfraction/PutInfractionRequest.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/PutInfraction/PutInfractionRequest.cs
@@ -1,0 +1,15 @@
+﻿using MediatR;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.PutInfraction
+{
+    public class PutInfractionRequest : IRequest<PutInfractionResponse>
+    {
+        public int InfractionId { get; set; }
+        public int UserId { get; set; }
+        public Infraction Infraction { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/PutInfraction/PutInfractionRequestHandler.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/PutInfraction/PutInfractionRequestHandler.cs
@@ -1,0 +1,53 @@
+﻿using AutoMapper;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Smash_Combos.Core.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.PutInfraction
+{
+    public class PutInfractionRequestHandler : IRequestHandler<PutInfractionRequest, PutInfractionResponse>
+    {
+        private readonly IDbContext _dbContext;
+        private readonly IMapper _mapper;
+
+        public PutInfractionRequestHandler(IDbContext dbContext, IMapper mapper)
+        {
+            _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        }
+
+        public async Task<PutInfractionResponse> Handle(PutInfractionRequest request, CancellationToken cancellationToken)
+        {
+            var infractionExists = await _dbContext.Infractions.Where(infraction => infraction.Id == request.InfractionId && infraction.User.Id == request.UserId).AnyAsync();
+
+            if (!infractionExists)
+                return new PutInfractionResponse { Success = false };
+
+            _dbContext.Entry(request.Infraction).State = EntityState.Modified;
+
+            try
+            {
+                await _dbContext.SaveChangesAsync(CancellationToken.None);
+                var comboToReturn = await _dbContext.Infractions.Where(infraction => infraction.Id == request.Infraction.Id).FirstOrDefaultAsync();
+                return new PutInfractionResponse { Success = true, Infraction = _mapper.Map<InfractionDto>(comboToReturn) };
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!_dbContext.Combos.Any(combo => combo.Id == request.InfractionId))
+                {
+                    return new PutInfractionResponse { Success = false };
+                }
+                else
+                {
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/PutInfraction/PutInfractionRequestHandler.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/PutInfraction/PutInfractionRequestHandler.cs
@@ -42,7 +42,11 @@ namespace Smash_Combos.Core.Cqrs.Infractions.PutInfraction
             try
             {
                 await _dbContext.SaveChangesAsync(CancellationToken.None);
-                var infractionToReturn = await _dbContext.Infractions.Where(infraction => infraction.Id == request.Id).FirstOrDefaultAsync();
+                var infractionToReturn = await _dbContext.Infractions
+                                                .Include(infraction => infraction.User)
+                                                .Include(infraction => infraction.Moderator)
+                                                .Where(infraction => infraction.Id == request.Id)
+                                                .FirstOrDefaultAsync();
                 return new PutInfractionResponse { Success = true, Infraction = _mapper.Map<InfractionDto>(infractionToReturn) };
             }
             catch (DbUpdateConcurrencyException)

--- a/Smash_Combos.Core/Cqrs/Infractions/PutInfraction/PutInfractionRequestHandler.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/PutInfraction/PutInfractionRequestHandler.cs
@@ -2,6 +2,7 @@
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Smash_Combos.Core.Services;
+using Smash_Combos.Domain.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -30,7 +31,7 @@ namespace Smash_Combos.Core.Cqrs.Infractions.PutInfraction
                 return new PutInfractionResponse { Success = false };
 
             infraction.BanDuration = request.BanDuration;
-            infraction.Points = request.Points;
+            infraction.Points = DeterminePoints(request);
             infraction.Category = request.Category;
             infraction.Body = request.Body;
 
@@ -60,6 +61,20 @@ namespace Smash_Combos.Core.Cqrs.Infractions.PutInfraction
                     throw;
                 }
             }
+        }
+        private int? DeterminePoints(PutInfractionRequest request)
+        {
+            if (request.Points != null)
+                return request.Points;
+
+            return request.Category switch
+            {
+                InfractionCategory.Spam => 1,
+                InfractionCategory.Inappropriate => 1,
+                InfractionCategory.Harassment => 2,
+                InfractionCategory.Other => request.Points,
+                _ => null,
+            };
         }
     }
 }

--- a/Smash_Combos.Core/Cqrs/Infractions/PutInfraction/PutInfractionResponse.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/PutInfraction/PutInfractionResponse.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.PutInfraction
+{
+    public class PutInfractionResponse
+    {
+        public InfractionDto Infraction { get; set; }
+        public bool Success { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Infractions/PutInfraction/UserDto.cs
+++ b/Smash_Combos.Core/Cqrs/Infractions/PutInfraction/UserDto.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Infractions.PutInfraction
+{
+    public class UserDto
+    {
+        public string DisplayName { get; set; }
+        public string Email { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/DeleteReport/DeleteReportProfile.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/DeleteReport/DeleteReportProfile.cs
@@ -1,0 +1,17 @@
+﻿using AutoMapper;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.DeleteReport
+{
+    public class DeleteReportProfile : Profile
+    {
+        public DeleteReportProfile()
+        {
+            CreateMap<Report, ReportDto>();
+            CreateMap<User, UserDto>();
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/DeleteReport/DeleteReportRequest.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/DeleteReport/DeleteReportRequest.cs
@@ -1,0 +1,13 @@
+﻿using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.DeleteReport
+{
+    public class DeleteReportRequest : IRequest<DeleteReportResponse>
+    {
+        public int ReportId { get; set; }
+        public int UserId { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/DeleteReport/DeleteReportRequestHandler.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/DeleteReport/DeleteReportRequestHandler.cs
@@ -1,0 +1,41 @@
+﻿using AutoMapper;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Smash_Combos.Core.Services;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Smash_Combos.Core.Cqrs.Reports.DeleteReport
+{
+    public class DeleteReportRequestHandler : IRequestHandler<DeleteReportRequest, DeleteReportResponse>
+    {
+        private readonly IDbContext _dbContext;
+        private readonly IMapper _mapper;
+
+        public DeleteReportRequestHandler(IDbContext dbContext, IMapper mapper)
+        {
+            _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        }
+
+        public async Task<DeleteReportResponse> Handle(DeleteReportRequest request, CancellationToken cancellationToken)
+        {
+            var report = await _dbContext.Reports
+                                .Include(report => report.User)
+                                .Include(report => report.Reporter)
+                                .Where(report => report.Id == request.ReportId && report.User.Id == request.UserId)
+                                .FirstOrDefaultAsync();
+            if (report == null)
+            {
+                return new DeleteReportResponse { Success = false };
+            }
+
+            _dbContext.Reports.Remove(report);
+            await _dbContext.SaveChangesAsync(CancellationToken.None);
+
+            return new DeleteReportResponse { Success = true, Report = _mapper.Map<ReportDto>(report) };
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/DeleteReport/DeleteReportResponse.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/DeleteReport/DeleteReportResponse.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.DeleteReport
+{
+    public class DeleteReportResponse
+    {
+        public bool Success { get; set; }
+        public ReportDto Report { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/DeleteReport/ReportDto.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/DeleteReport/ReportDto.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.DeleteReport
+{
+    public class ReportDto
+    {
+        public int Id { get; set; }
+
+        public UserDto User { get; set; }
+
+        public UserDto Reporter { get; set; }
+
+        public string Body { get; set; }
+
+        public DateTime DateReported { get; set; }
+
+        public bool Dismiss { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/DeleteReport/UserDto.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/DeleteReport/UserDto.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.DeleteReport
+{
+    public class UserDto
+    {
+        public string DisplayName { get; set; }
+        public string Email { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/GetReport/GetReportProfile.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/GetReport/GetReportProfile.cs
@@ -1,0 +1,17 @@
+﻿using AutoMapper;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.GetReport
+{
+    public class GetReportProfile : Profile
+    {
+        public GetReportProfile()
+        {
+            CreateMap<Report, GetReportResponse>();
+            CreateMap<User, UserDto>();
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/GetReport/GetReportRequest.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/GetReport/GetReportRequest.cs
@@ -1,0 +1,12 @@
+﻿using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.GetReport
+{
+    public class GetReportRequest : IRequest<GetReportResponse>
+    {
+        public int ReportId { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/GetReport/GetReportRequestHandler.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/GetReport/GetReportRequestHandler.cs
@@ -1,0 +1,37 @@
+﻿using AutoMapper;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Smash_Combos.Core.Services;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Smash_Combos.Core.Cqrs.Reports.GetReport
+{
+    public class GetReportRequestHandler : IRequestHandler<GetReportRequest, GetReportResponse>
+    {
+        private readonly IDbContext _dbContext;
+        private readonly IMapper _mapper;
+
+        public GetReportRequestHandler(IDbContext dbContext, IMapper mapper)
+        {
+            _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        }
+
+        public async Task<GetReportResponse> Handle(GetReportRequest request, CancellationToken cancellationToken)
+        {
+            var report = await _dbContext.Reports
+                .Where(report => report.Id == request.ReportId)
+                .Include(report => report.User)
+                .Include(report => report.Reporter)
+                .FirstOrDefaultAsync();
+
+            if (report == null)
+                return null;
+
+            return _mapper.Map<GetReportResponse>(report);
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/GetReport/GetReportResponse.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/GetReport/GetReportResponse.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.GetReport
+{
+    public class GetReportResponse
+    {
+        public int Id { get; set; }
+
+        public UserDto User { get; set; }
+
+        public UserDto Reporter { get; set; }
+
+        public string Body { get; set; }
+
+        public DateTime DateReported { get; set; }
+
+        public bool Dismiss { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/GetReport/UserDto.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/GetReport/UserDto.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.GetReport
+{
+    public class UserDto
+    {
+        public int Id { get; set; }
+        public string DisplayName { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/GetReports/GetReportsProfile.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/GetReports/GetReportsProfile.cs
@@ -1,0 +1,17 @@
+﻿using AutoMapper;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.GetReports
+{
+    public class GetReportsProfile : Profile
+    {
+        public GetReportsProfile()
+        {
+            CreateMap<Report, GetReportsResponse>();
+            CreateMap<User, UserDto>();
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/GetReports/GetReportsRequest.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/GetReports/GetReportsRequest.cs
@@ -1,0 +1,11 @@
+﻿using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.GetReports
+{
+    public class GetReportsRequest : IRequest<IEnumerable<GetReportsResponse>>
+    {
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/GetReports/GetReportsRequestHandler.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/GetReports/GetReportsRequestHandler.cs
@@ -1,0 +1,34 @@
+﻿using AutoMapper;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Smash_Combos.Core.Services;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Smash_Combos.Core.Cqrs.Reports.GetReports
+{
+    public class GetReportsRequestHandler : IRequestHandler<GetReportsRequest, IEnumerable<GetReportsResponse>>
+    {
+        private readonly IDbContext _dbContext;
+        private readonly IMapper _mapper;
+
+        public GetReportsRequestHandler(IDbContext dbContext, IMapper mapper)
+        {
+            _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        }
+
+        public async Task<IEnumerable<GetReportsResponse>> Handle(GetReportsRequest request, CancellationToken cancellationToken)
+        {
+            var reports = await _dbContext.Reports
+                .Include(infraction => infraction.User)
+                .Include(infraction => infraction.Reporter)
+                .ToListAsync();
+
+            return _mapper.Map<IEnumerable<GetReportsResponse>>(reports);
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/GetReports/GetReportsResponse.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/GetReports/GetReportsResponse.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.GetReports
+{
+    public class GetReportsResponse
+    {
+        public int Id { get; set; }
+
+        public UserDto User { get; set; }
+
+        public UserDto Reporter { get; set; }
+
+        public string Body { get; set; }
+
+        public DateTime DateReported { get; set; }
+
+        public bool Dismiss { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/GetReports/UserDto.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/GetReports/UserDto.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.GetReports
+{
+    public class UserDto
+    {
+        public int Id { get; set; }
+        public string DisplayName { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/PostComboReport/PostComboReportProfile.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/PostComboReport/PostComboReportProfile.cs
@@ -1,0 +1,17 @@
+﻿using AutoMapper;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.PostComboReport
+{
+    public class PostComboReportProfile : Profile
+    {
+        public PostComboReportProfile()
+        {
+            CreateMap<Report, PostComboReportResponse>();
+            CreateMap<User, UserDto>();
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/PostComboReport/PostComboReportRequest.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/PostComboReport/PostComboReportRequest.cs
@@ -1,0 +1,19 @@
+﻿using MediatR;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.PostComboReport
+{
+    public class PostComboReportRequest : IRequest<PostComboReportResponse>
+    {
+        public int UserId { get; set; }
+
+        public int ReporterId { get; set; }
+
+        public int ComboId { get; set; }
+
+        public string Body { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/PostComboReport/PostComboReportRequestHandler.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/PostComboReport/PostComboReportRequestHandler.cs
@@ -1,0 +1,51 @@
+﻿using AutoMapper;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Smash_Combos.Core.Services;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Smash_Combos.Core.Cqrs.Reports.PostComboReport
+{
+    public class PostComboReportRequestHandler : IRequestHandler<PostComboReportRequest, PostComboReportResponse>
+    {
+        private readonly IDbContext _dbContext;
+        private readonly IMapper _mapper;
+
+        public PostComboReportRequestHandler(IDbContext dbContext, IMapper mapper)
+        {
+            _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        }
+
+        public async Task<PostComboReportResponse> Handle(PostComboReportRequest request, CancellationToken cancellationToken)
+        {
+            var user = await _dbContext.Users.Where(user => user.Id == request.UserId).FirstOrDefaultAsync();
+            var reporter = await _dbContext.Users.Where(user => user.Id == request.ReporterId).FirstOrDefaultAsync();
+            var reportCombo = await _dbContext.Combos.Where(combo => combo.Id == request.ComboId).FirstOrDefaultAsync();
+
+            if(user == null || reporter == null || reportCombo == null)
+                return new PostComboReportResponse { User = null, Reporter = null };
+
+            var report = new Report
+            {
+                User = user,
+                Reporter = reporter,
+                Body = request.Body
+            };
+            _dbContext.Reports.Add(report);
+
+            reportCombo.Reports.Add(report);
+            _dbContext.Entry(reportCombo).State = EntityState.Modified;
+
+            await _dbContext.SaveChangesAsync(CancellationToken.None);
+
+            return _mapper.Map<PostComboReportResponse>(report);
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/PostComboReport/PostComboReportResponse.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/PostComboReport/PostComboReportResponse.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.PostComboReport
+{
+    public class PostComboReportResponse
+    {
+        public int Id { get; set; }
+
+        public UserDto User { get; set; }
+
+        public UserDto Reporter { get; set; }
+
+        public string Body { get; set; }
+
+        public DateTime DateReported { get; set; }
+
+        public bool Dismiss { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/PostComboReport/UserDto.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/PostComboReport/UserDto.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.PostComboReport
+{
+    public class UserDto
+    {
+        public int Id { get; set; }
+        public string DisplayName { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/PostCommentReport/PostCommentReportProfile.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/PostCommentReport/PostCommentReportProfile.cs
@@ -1,0 +1,17 @@
+﻿using AutoMapper;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.PostCommentReport
+{
+    public class PostCommentReportProfile : Profile
+    {
+        public PostCommentReportProfile()
+        {
+            CreateMap<Report, PostCommentReportResponse>();
+            CreateMap<User, UserDto>();
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/PostCommentReport/PostCommentReportRequest.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/PostCommentReport/PostCommentReportRequest.cs
@@ -1,0 +1,19 @@
+﻿using MediatR;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.PostCommentReport
+{
+    public class PostCommentReportRequest : IRequest<PostCommentReportResponse>
+    {
+        public int UserId { get; set; }
+
+        public int ReporterId { get; set; }
+
+        public int CommentId { get; set; }
+
+        public string Body { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/PostCommentReport/PostCommentReportRequestHandler.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/PostCommentReport/PostCommentReportRequestHandler.cs
@@ -1,0 +1,51 @@
+﻿using AutoMapper;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Smash_Combos.Core.Services;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Smash_Combos.Core.Cqrs.Reports.PostCommentReport
+{
+    public class PostCommentReportRequestHandler : IRequestHandler<PostCommentReportRequest, PostCommentReportResponse>
+    {
+        private readonly IDbContext _dbContext;
+        private readonly IMapper _mapper;
+
+        public PostCommentReportRequestHandler(IDbContext dbContext, IMapper mapper)
+        {
+            _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        }
+
+        public async Task<PostCommentReportResponse> Handle(PostCommentReportRequest request, CancellationToken cancellationToken)
+        {
+            var user = await _dbContext.Users.Where(user => user.Id == request.UserId).FirstOrDefaultAsync();
+            var reporter = await _dbContext.Users.Where(user => user.Id == request.ReporterId).FirstOrDefaultAsync();
+            var comment = await _dbContext.Comments.Where(comment => comment.Id == request.CommentId).FirstOrDefaultAsync();
+
+            if(user == null || reporter == null)
+                return new PostCommentReportResponse { User = null, Reporter = null };
+
+            var report = new Report
+            {
+                User = user,
+                Reporter = reporter,
+                Body = request.Body
+            };
+            _dbContext.Reports.Add(report);
+
+            comment.Reports.Add(report);
+            _dbContext.Entry(comment).State = EntityState.Modified;
+
+            await _dbContext.SaveChangesAsync(CancellationToken.None);
+
+            return _mapper.Map<PostCommentReportResponse>(report);
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/PostCommentReport/PostCommentReportResponse.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/PostCommentReport/PostCommentReportResponse.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.PostCommentReport
+{
+    public class PostCommentReportResponse
+    {
+        public int Id { get; set; }
+
+        public UserDto User { get; set; }
+
+        public UserDto Reporter { get; set; }
+
+        public string Body { get; set; }
+
+        public DateTime DateReported { get; set; }
+
+        public bool Dismiss { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/PostCommentReport/UserDto.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/PostCommentReport/UserDto.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.PostCommentReport
+{
+    public class UserDto
+    {
+        public int Id { get; set; }
+        public string DisplayName { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/PutReport/PutReportProfile.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/PutReport/PutReportProfile.cs
@@ -1,0 +1,17 @@
+﻿using AutoMapper;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.PutReport
+{
+    public class PutReportProfile : Profile
+    {
+        public PutReportProfile()
+        {
+            CreateMap<Report, ReportDto>();
+            CreateMap<User, UserDto>();
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/PutReport/PutReportRequest.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/PutReport/PutReportRequest.cs
@@ -1,0 +1,14 @@
+﻿using MediatR;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.PutReport
+{
+    public class PutReportRequest : IRequest<PutReportResponse>
+    {
+        public int Id { get; set; }
+        public bool Dismiss { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/PutReport/PutReportRequestHandler.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/PutReport/PutReportRequestHandler.cs
@@ -1,0 +1,60 @@
+﻿using AutoMapper;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Smash_Combos.Core.Services;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Smash_Combos.Core.Cqrs.Reports.PutReport
+{
+    public class PutReportRequestHandler : IRequestHandler<PutReportRequest, PutReportResponse>
+    {
+        private readonly IDbContext _dbContext;
+        private readonly IMapper _mapper;
+
+        public PutReportRequestHandler(IDbContext dbContext, IMapper mapper)
+        {
+            _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        }
+
+        public async Task<PutReportResponse> Handle(PutReportRequest request, CancellationToken cancellationToken)
+        {
+            var report = await _dbContext.Reports.Where(report => report.Id == request.Id).FirstOrDefaultAsync();
+
+            if (report == null)
+                return new PutReportResponse { Success = false };
+
+            report.Dismiss = request.Dismiss;
+
+            _dbContext.Entry(report).State = EntityState.Modified;
+
+            try
+            {
+                await _dbContext.SaveChangesAsync(CancellationToken.None);
+                var reportToReturn = await _dbContext.Reports
+                                            .Include(report => report.User)
+                                            .Include(report => report.Reporter)
+                                            .Where(dbReport => dbReport.Id == report.Id)
+                                            .FirstOrDefaultAsync();
+                return new PutReportResponse { Success = true, Report = _mapper.Map<ReportDto>(reportToReturn) };
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!_dbContext.Reports.Any(report => report.Id == request.Id))
+                {
+                    return new PutReportResponse { Success = false };
+                }
+                else
+                {
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/PutReport/PutReportResponse.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/PutReport/PutReportResponse.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.PutReport
+{
+    public class PutReportResponse
+    {
+        public ReportDto Report { get; set; }
+        public bool Success { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/PutReport/ReportDto.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/PutReport/ReportDto.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.PutReport
+{
+    public class ReportDto
+    {
+        public int Id { get; set; }
+
+        public UserDto User { get; set; }
+
+        public UserDto Reporter { get; set; }
+
+        public string Body { get; set; }
+
+        public DateTime DateReported { get; set; }
+
+        public bool Dismiss { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Reports/PutReport/UserDto.cs
+++ b/Smash_Combos.Core/Cqrs/Reports/PutReport/UserDto.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Reports.PutReport
+{
+    public class UserDto
+    {
+        public int Id { get; set; }
+        public string DisplayName { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/ResponseBase.cs
+++ b/Smash_Combos.Core/Cqrs/ResponseBase.cs
@@ -6,7 +6,8 @@ namespace Smash_Combos.Core.Cqrs
 {
     public abstract class ResponseBase
     {
-        public ResponseStatus Status { get; set; }
+        public ResponseStatus ResponseStatus { get; set; }
+        public string ResponseMessage { get; set; }
     }
 
     public abstract class ResponseBase<T> : ResponseBase

--- a/Smash_Combos.Core/Cqrs/ResponseBase.cs
+++ b/Smash_Combos.Core/Cqrs/ResponseBase.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs
+{
+    public abstract class ResponseBase
+    {
+        public ResponseStatus Status { get; set; }
+    }
+
+    public abstract class ResponseBase<T> : ResponseBase
+    {
+        public T Data { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/ResponseStatus.cs
+++ b/Smash_Combos.Core/Cqrs/ResponseStatus.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs
+{
+    public enum ResponseStatus
+    {
+        Ok,             // Everything went as expected, the request was fulfilled
+        NotFound,       // The resource requested was not found
+        BadRequest,     // The request contained errors/faulty data
+        NotAuthorized,  // The sender was not authorized for the request
+        Error           // Something went wrong internally
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Sessions/Login/LoginProfile.cs
+++ b/Smash_Combos.Core/Cqrs/Sessions/Login/LoginProfile.cs
@@ -1,0 +1,16 @@
+﻿using AutoMapper;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Sessions.Login
+{
+    public class LoginProfile : Profile
+    {
+        public LoginProfile()
+        {
+            CreateMap<User, UserDto>();
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Sessions/Login/LoginRequest.cs
+++ b/Smash_Combos.Core/Cqrs/Sessions/Login/LoginRequest.cs
@@ -1,0 +1,13 @@
+﻿using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Sessions.Login
+{
+    public class LoginRequest : IRequest<LoginResponse>
+    {
+        public string Email { get; set; }
+        public string Password { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Sessions/Login/LoginRequestHandler.cs
+++ b/Smash_Combos.Core/Cqrs/Sessions/Login/LoginRequestHandler.cs
@@ -1,0 +1,55 @@
+﻿using AutoMapper;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Smash_Combos.Core.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Smash_Combos.Core.Cqrs.Sessions.Login
+{
+    public class LoginRequestHandler : IRequestHandler<LoginRequest, LoginResponse>
+    {
+        private readonly IDbContext _dbContext;
+        private readonly IMapper _mapper;
+        private readonly string JWT_KEY;
+
+        public LoginRequestHandler(IDbContext dbContext, IMapper mapper, IConfiguration config)
+        {
+            _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+            
+            if(config == null) 
+                throw new ArgumentNullException(nameof(config));
+           
+            JWT_KEY = config["JWT_KEY"];
+        }
+
+        public async Task<LoginResponse> Handle(LoginRequest request, CancellationToken cancellationToken)
+        {
+            var foundUser = await _dbContext.Users.Include(x => x.Infractions).FirstOrDefaultAsync(user => user.Email.ToLower() == request.Email.ToLower());
+            if (foundUser != null && foundUser.IsValidPassword(request.Password))
+            {
+                foreach(var infraction in foundUser.Infractions)
+                {
+                    if (infraction.IsActiveBan())
+                        return new LoginResponse { ResponseMessage = "User is currently banned" };
+                }
+                var user = _mapper.Map<UserDto>(foundUser);
+                return new LoginResponse { Token = new TokenGenerator(JWT_KEY).TokenFor(user), User = user };
+            }
+            if (foundUser != null && !foundUser.IsValidPassword(request.Password))
+            {
+                return new LoginResponse { ResponseMessage = "Invalid Password", User = _mapper.Map<UserDto>(foundUser) };
+            }
+            else
+            {
+                return new LoginResponse { ResponseMessage = "User does not exist" };
+            }
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Sessions/Login/LoginResponse.cs
+++ b/Smash_Combos.Core/Cqrs/Sessions/Login/LoginResponse.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Sessions.Login
+{
+    public class LoginResponse
+    {
+        public string ResponseMessage { get; set; }
+        public string Token { get; set; }
+        public UserDto User { get; set; }
+        public bool PasswordIsValid { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Sessions/Login/TokenGenerator.cs
+++ b/Smash_Combos.Core/Cqrs/Sessions/Login/TokenGenerator.cs
@@ -1,12 +1,13 @@
-using Microsoft.IdentityModel.Tokens;
+﻿using Microsoft.IdentityModel.Tokens;
 using System;
+using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
 
-namespace Smash_Combos.Controllers
+namespace Smash_Combos.Core.Cqrs.Sessions.Login
 {
     public class TokenGenerator
     {

--- a/Smash_Combos.Core/Cqrs/Sessions/Login/UserDto.cs
+++ b/Smash_Combos.Core/Cqrs/Sessions/Login/UserDto.cs
@@ -3,12 +3,13 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Smash_Combos.Core.Cqrs.Users.GetUser
+namespace Smash_Combos.Core.Cqrs.Sessions.Login
 {
     public class UserDto
     {
         public int Id { get; set; }
+        public string Email { get; set; }
         public string DisplayName { get; set; }
-        public UserType UserType { get; private set; }
+        public UserType UserType { get; set; }
     }
 }

--- a/Smash_Combos.Core/Cqrs/Users/GetUser/ComboDto.cs
+++ b/Smash_Combos.Core/Cqrs/Users/GetUser/ComboDto.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.GetUser
+{
+    public class ComboDto
+    {
+        public int Id { get; set; }
+
+        public int CharacterId { get; set; }
+
+        public DateTime DatePosted { get; set; }
+
+        public List<ReportDto> Reports { get; set; } = new List<ReportDto>();
+
+        public string Title { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/GetUser/CommentDto.cs
+++ b/Smash_Combos.Core/Cqrs/Users/GetUser/CommentDto.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.GetUser
+{
+    public class CommentDto
+    {
+        public int Id { get; set; }
+        public DateTime DatePosted { get; set; }
+        public string Body { get; set; }
+        public List<ReportDto> Reports { get; set; } = new List<ReportDto>();
+        public int NetVote { get; private set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/GetUser/GetUserProfile.cs
+++ b/Smash_Combos.Core/Cqrs/Users/GetUser/GetUserProfile.cs
@@ -1,0 +1,20 @@
+﻿using AutoMapper;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.GetUser
+{
+    public class GetUserProfile : Profile
+    {
+        public GetUserProfile()
+        {
+            CreateMap<User, UserDto>();
+            CreateMap<Combo, ComboDto>();
+            CreateMap<Report, ReportDto>();
+            CreateMap<Comment, CommentDto>();
+            CreateMap<Infraction, InfractionDto>();
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/GetUser/GetUserRequest.cs
+++ b/Smash_Combos.Core/Cqrs/Users/GetUser/GetUserRequest.cs
@@ -1,0 +1,13 @@
+﻿using MediatR;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.GetUser
+{
+    public class GetUserRequest : IRequest<GetUserResponse>
+    {
+        public int UserId { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/GetUser/GetUserRequestHandler.cs
+++ b/Smash_Combos.Core/Cqrs/Users/GetUser/GetUserRequestHandler.cs
@@ -1,0 +1,52 @@
+﻿using AutoMapper;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Smash_Combos.Core.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Smash_Combos.Core.Cqrs.Users.GetUser
+{
+    public class PostUserRequestHandler : IRequestHandler<GetUserRequest, GetUserResponse>
+    {
+        private readonly IDbContext _dbContext;
+        private readonly IMapper _mapper;
+
+        public PostUserRequestHandler(IDbContext dbContext, IMapper mapper)
+        {
+            _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        }
+
+        public async Task<GetUserResponse> Handle(GetUserRequest request, CancellationToken cancellationToken)
+        {
+            var user = await _dbContext.Users
+                        .Include(user => user.Combos)
+                            .ThenInclude(combo => combo.Reports)
+                        .Include(user => user.Comments)
+                            .ThenInclude(comment => comment.Reports)
+                        .Include(user => user.Infractions)
+                        .Where(user => user.Id == request.UserId)
+                        .FirstOrDefaultAsync();
+
+            if (user == null)
+                return null;
+
+            var response = new GetUserResponse
+            {
+                Id = user.Id,
+                DisplayName = user.DisplayName,
+                UserType = user.UserType,
+                Combos = _mapper.Map<List<ComboDto>>(user.Combos),
+                Comments = _mapper.Map<List<CommentDto>>(user.Comments),
+                Infractions = _mapper.Map<List<InfractionDto>>(user.Infractions)
+            };
+
+            return response;
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/GetUser/GetUserResponse.cs
+++ b/Smash_Combos.Core/Cqrs/Users/GetUser/GetUserResponse.cs
@@ -1,0 +1,22 @@
+﻿using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.GetUser
+{
+    public class GetUserResponse
+    {
+        public int Id { get; set; }
+
+        public string DisplayName { get; set; }
+
+        public UserType UserType { get; set; }
+
+        public List<ComboDto> Combos { get; set; }
+
+        public List<CommentDto> Comments { get; set; }
+
+        public List<InfractionDto> Infractions { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/GetUser/InfractionDto.cs
+++ b/Smash_Combos.Core/Cqrs/Users/GetUser/InfractionDto.cs
@@ -1,0 +1,28 @@
+﻿using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.GetUser
+{
+    public class InfractionDto
+    {
+        public int Id { get; set; }
+
+        public UserDto User { get; set; }
+
+        public UserDto Moderator { get; set; }
+
+        public int? BanDuration { get; set; }
+
+        public DateTime? BanLiftDate { get; set; }
+
+        public int? Points { get; private set; }
+
+        public InfractionCategory Category { get; set; }
+
+        public string Body { get; set; }
+
+        public DateTime DateInfracted { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/GetUser/ReportDto.cs
+++ b/Smash_Combos.Core/Cqrs/Users/GetUser/ReportDto.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.GetUser
+{
+    public class ReportDto
+    {
+        public int Id { get; set; }
+
+        public UserDto User { get; set; }
+
+        public UserDto Reporter { get; set; }
+
+        public string Body { get; set; }
+
+        public DateTime DateReported { get; set; }
+
+        public bool Dismiss { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/GetUser/UserDto.cs
+++ b/Smash_Combos.Core/Cqrs/Users/GetUser/UserDto.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.GetUser
+{
+    public class UserDto
+    {
+        public int Id { get; set; }
+        public string DisplayName { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/GetUsers/ComboDto.cs
+++ b/Smash_Combos.Core/Cqrs/Users/GetUsers/ComboDto.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.GetUsers
+{
+    public class ComboDto
+    {
+        public int Id { get; set; }
+
+        public int CharacterId { get; set; }
+
+        public DateTime DatePosted { get; set; }
+
+        public List<ReportDto> Reports { get; set; } = new List<ReportDto>();
+
+        public string Title { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/GetUsers/CommentDto.cs
+++ b/Smash_Combos.Core/Cqrs/Users/GetUsers/CommentDto.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.GetUsers
+{
+    public class CommentDto
+    {
+        public int Id { get; set; }
+        public DateTime DatePosted { get; set; }
+        public string Body { get; set; }
+        public List<ReportDto> Reports { get; set; } = new List<ReportDto>();
+        public int NetVote { get; private set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/GetUsers/GetUsersProfile.cs
+++ b/Smash_Combos.Core/Cqrs/Users/GetUsers/GetUsersProfile.cs
@@ -1,0 +1,20 @@
+﻿using AutoMapper;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.GetUsers
+{
+    public class GetUsersProfile : Profile
+    {
+        public GetUsersProfile()
+        {
+            CreateMap<User, UserDto>();
+            CreateMap<Combo, ComboDto>();
+            CreateMap<Report, ReportDto>();
+            CreateMap<Comment, CommentDto>();
+            CreateMap<Infraction, InfractionDto>();
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/GetUsers/GetUsersRequest.cs
+++ b/Smash_Combos.Core/Cqrs/Users/GetUsers/GetUsersRequest.cs
@@ -1,0 +1,11 @@
+﻿using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.GetUsers
+{
+    public class GetUsersRequest : IRequest<IEnumerable<GetUsersResponse>>
+    {
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/GetUsers/GetUsersRequestHandler.cs
+++ b/Smash_Combos.Core/Cqrs/Users/GetUsers/GetUsersRequestHandler.cs
@@ -1,0 +1,54 @@
+﻿using AutoMapper;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Smash_Combos.Core.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Smash_Combos.Core.Cqrs.Users.GetUsers
+{
+    public class GetUsersRequestHandler : IRequestHandler<GetUsersRequest, IEnumerable<GetUsersResponse>>
+    {
+        private readonly IDbContext _dbContext;
+        private readonly IMapper _mapper;
+
+        public GetUsersRequestHandler(IDbContext dbContext, IMapper mapper)
+        {
+            _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        }
+
+        public async Task<IEnumerable<GetUsersResponse>> Handle(GetUsersRequest request, CancellationToken cancellationToken)
+        {
+            var users = await _dbContext.Users
+                        .Include(user => user.Combos)
+                            .ThenInclude(combo => combo.Reports)
+                        .Include(user => user.Comments)
+                            .ThenInclude(comment => comment.Reports)
+                        .Include(user => user.Infractions)
+                        .ToListAsync();
+
+            var responseList = new List<GetUsersResponse>();
+
+            foreach(var user in users)
+            {
+                var response = new GetUsersResponse
+                {
+                    Id = user.Id,
+                    DisplayName = user.DisplayName,
+                    UserType = user.UserType,
+                    Combos = _mapper.Map<List<ComboDto>>(user.Combos),
+                    Comments = _mapper.Map<List<CommentDto>>(user.Comments),
+                    Infractions = _mapper.Map<List<InfractionDto>>(user.Infractions)
+                };
+                responseList.Add(response);
+            }
+
+            return responseList;
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/GetUsers/GetUsersResponse.cs
+++ b/Smash_Combos.Core/Cqrs/Users/GetUsers/GetUsersResponse.cs
@@ -1,0 +1,22 @@
+﻿using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.GetUsers
+{
+    public class GetUsersResponse
+    {
+        public int Id { get; set; }
+
+        public string DisplayName { get; set; }
+
+        public UserType UserType { get; set; }
+
+        public List<ComboDto> Combos { get; set; }
+
+        public List<CommentDto> Comments { get; set; }
+
+        public List<InfractionDto> Infractions { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/GetUsers/InfractionDto.cs
+++ b/Smash_Combos.Core/Cqrs/Users/GetUsers/InfractionDto.cs
@@ -1,0 +1,28 @@
+﻿using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.GetUsers
+{
+    public class InfractionDto
+    {
+        public int Id { get; set; }
+
+        public UserDto User { get; set; }
+
+        public UserDto Moderator { get; set; }
+
+        public int? BanDuration { get; set; }
+
+        public DateTime? BanLiftDate { get; set; }
+
+        public int? Points { get; private set; }
+
+        public InfractionCategory Category { get; set; }
+
+        public string Body { get; set; }
+
+        public DateTime DateInfracted { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/GetUsers/ReportDto.cs
+++ b/Smash_Combos.Core/Cqrs/Users/GetUsers/ReportDto.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.GetUsers
+{
+    public class ReportDto
+    {
+        public int Id { get; set; }
+
+        public UserDto User { get; set; }
+
+        public UserDto Reporter { get; set; }
+
+        public string Body { get; set; }
+
+        public DateTime DateReported { get; set; }
+
+        public bool Dismiss { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/GetUsers/UserDto.cs
+++ b/Smash_Combos.Core/Cqrs/Users/GetUsers/UserDto.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.GetUsers
+{
+    public class UserDto
+    {
+        public int Id { get; set; }
+        public string DisplayName { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/PostUser/PostUserRequest.cs
+++ b/Smash_Combos.Core/Cqrs/Users/PostUser/PostUserRequest.cs
@@ -1,0 +1,14 @@
+﻿using MediatR;
+using Microsoft.AspNetCore.Identity;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.PostUser
+{
+    public class PostUserRequest : IRequest<PostUserResponse>
+    {
+        public User User { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/PostUser/PostUserRequestHandler.cs
+++ b/Smash_Combos.Core/Cqrs/Users/PostUser/PostUserRequestHandler.cs
@@ -1,0 +1,45 @@
+﻿using AutoMapper;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Smash_Combos.Core.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Smash_Combos.Core.Cqrs.Users.PostUser
+{
+    public class PostUserRequestHandler : IRequestHandler<PostUserRequest, PostUserResponse>
+    {
+        private readonly IDbContext _dbContext;
+
+        public PostUserRequestHandler(IDbContext dbContext)
+        {
+            _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        }
+
+        public async Task<PostUserResponse> Handle(PostUserRequest request, CancellationToken cancellationToken)
+        {
+            var emailExists = _dbContext.Users.Any(existingUser => existingUser.Email.ToLower() == request.User.Email.ToLower());
+            var displayNameExists = _dbContext.Users.Any(existingUser => existingUser.DisplayName.ToLower() == request.User.DisplayName.ToLower());
+
+            if (displayNameExists)
+                return new PostUserResponse { DisplayNameAlreadyExists = true };
+
+            if (emailExists)
+                return new PostUserResponse { EmailAlreadyExists = true };
+
+            if (!request.User.PasswordMeetsCriteria)
+                return new PostUserResponse { PasswordDoesntMeetCriteria = true };
+
+
+            // Indicate to the database context we want to add this new record
+            _dbContext.Users.Add(request.User);
+            await _dbContext.SaveChangesAsync(CancellationToken.None);
+
+            return new PostUserResponse { User = request.User };
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/PostUser/PostUserResponse.cs
+++ b/Smash_Combos.Core/Cqrs/Users/PostUser/PostUserResponse.cs
@@ -1,0 +1,16 @@
+﻿using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.PostUser
+{
+    public class PostUserResponse
+    {
+        public User User { get; set; }
+
+        public bool EmailAlreadyExists { get; set; }
+        public bool DisplayNameAlreadyExists { get; set; }
+        public bool PasswordDoesntMeetCriteria { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/UnbanUser/ComboDto.cs
+++ b/Smash_Combos.Core/Cqrs/Users/UnbanUser/ComboDto.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.UnbanUser
+{
+    public class ComboDto
+    {
+        public int Id { get; set; }
+
+        public int CharacterId { get; set; }
+
+        public DateTime DatePosted { get; set; }
+
+        public List<ReportDto> Reports { get; set; } = new List<ReportDto>();
+
+        public string Title { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/UnbanUser/CommentDto.cs
+++ b/Smash_Combos.Core/Cqrs/Users/UnbanUser/CommentDto.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.UnbanUser
+{
+    public class CommentDto
+    {
+        public int Id { get; set; }
+        public DateTime DatePosted { get; set; }
+        public string Body { get; set; }
+        public List<ReportDto> Reports { get; set; } = new List<ReportDto>();
+        public int NetVote { get; private set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/UnbanUser/InfractionDto.cs
+++ b/Smash_Combos.Core/Cqrs/Users/UnbanUser/InfractionDto.cs
@@ -1,0 +1,28 @@
+﻿using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.UnbanUser
+{
+    public class InfractionDto
+    {
+        public int Id { get; set; }
+
+        public UserDto User { get; set; }
+
+        public UserDto Moderator { get; set; }
+
+        public int? BanDuration { get; set; }
+
+        public DateTime? BanLiftDate { get; set; }
+
+        public int? Points { get; private set; }
+
+        public InfractionCategory Category { get; set; }
+
+        public string Body { get; set; }
+
+        public DateTime DateInfracted { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/UnbanUser/ReportDto.cs
+++ b/Smash_Combos.Core/Cqrs/Users/UnbanUser/ReportDto.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.UnbanUser
+{
+    public class ReportDto
+    {
+        public int Id { get; set; }
+
+        public UserDto User { get; set; }
+
+        public UserDto Reporter { get; set; }
+
+        public string Body { get; set; }
+
+        public DateTime DateReported { get; set; }
+
+        public bool Dismiss { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/UnbanUser/UnbanUserProfile.cs
+++ b/Smash_Combos.Core/Cqrs/Users/UnbanUser/UnbanUserProfile.cs
@@ -1,0 +1,20 @@
+﻿using AutoMapper;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.UnbanUser
+{
+    public class UnbanUserProfile : Profile
+    {
+        public UnbanUserProfile()
+        {
+            CreateMap<User, UnbanUserResponse>();
+            CreateMap<User, UserDto>();
+            CreateMap<Combo, ComboDto>();
+            CreateMap<Comment, CommentDto>();
+            CreateMap<Infraction, InfractionDto>();
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/UnbanUser/UnbanUserRequest.cs
+++ b/Smash_Combos.Core/Cqrs/Users/UnbanUser/UnbanUserRequest.cs
@@ -1,0 +1,13 @@
+﻿using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.UnbanUser
+{
+    public class UnbanUserRequest : IRequest<UnbanUserResponse>
+    {
+        public int UserId { get; set; }
+        public int ModeratorId { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/UnbanUser/UnbanUserRequestHandler.cs
+++ b/Smash_Combos.Core/Cqrs/Users/UnbanUser/UnbanUserRequestHandler.cs
@@ -1,0 +1,58 @@
+﻿using AutoMapper;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Smash_Combos.Core.Cqrs.Characters.GetCharacter;
+using Smash_Combos.Core.Services;
+using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Smash_Combos.Core.Cqrs.Users.UnbanUser
+{
+    public class UnbanUserRequestHandler : IRequestHandler<UnbanUserRequest, UnbanUserResponse>
+    {
+        private readonly IDbContext _dbContext;
+        private readonly IMapper _mapper;
+
+        public UnbanUserRequestHandler(IDbContext dbContext, IMapper mapper)
+        {
+            _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        }
+
+        public async Task<UnbanUserResponse> Handle(UnbanUserRequest unbanRequest, CancellationToken cancellationToken)
+        {
+            var moderator = await _dbContext.Users.Where(user => user.Id == unbanRequest.ModeratorId).FirstOrDefaultAsync();
+
+            if (moderator == null || (moderator.UserType != UserType.Moderator && moderator.UserType != UserType.Admin))
+                return null;
+
+            var user = await _dbContext.Users.Include(user => user.Combos)
+                                .Include(user => user.Comments)
+                                .Include(user => user.Combos)
+                                .Include(user => user.Infractions)
+                                .FirstOrDefaultAsync(user => user.Id == unbanRequest.UserId);
+
+            if (user == null)
+                return null;
+
+            var infractions = await _dbContext.Infractions.Where(infraction => infraction.User.Id == unbanRequest.UserId).ToListAsync();
+
+            foreach(var infraction in infractions)
+            {
+                if (infraction.IsActiveBan())
+                {
+                    infraction.BanLiftDate = DateTime.Now;
+                }
+            }
+
+            await _dbContext.SaveChangesAsync(CancellationToken.None);
+
+            return _mapper.Map<UnbanUserResponse>(user);
+        }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/UnbanUser/UnbanUserResponse.cs
+++ b/Smash_Combos.Core/Cqrs/Users/UnbanUser/UnbanUserResponse.cs
@@ -1,0 +1,18 @@
+﻿using Smash_Combos.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Smash_Combos.Core.Cqrs.Users.UnbanUser
+{
+    public class UnbanUserResponse
+    {
+        public int Id { get; set; }
+        public string DisplayName { get; set; }
+        public UserType UserType { get; set; }
+
+        public List<ComboDto> Combos { get; set; }
+        public List<CommentDto> Comments { get; set; }
+        public List<InfractionDto> Infractions { get; set; }
+    }
+}

--- a/Smash_Combos.Core/Cqrs/Users/UnbanUser/UserDto.cs
+++ b/Smash_Combos.Core/Cqrs/Users/UnbanUser/UserDto.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Smash_Combos.Core.Cqrs.Users.GetUser
+namespace Smash_Combos.Core.Cqrs.Users.UnbanUser
 {
     public class UserDto
     {

--- a/Smash_Combos.Core/Smash_Combos.Core.csproj
+++ b/Smash_Combos.Core/Smash_Combos.Core.csproj
@@ -8,6 +8,8 @@
     <PackageReference Include="AutoMapper" Version="10.0.0" />
     <PackageReference Include="MediatR" Version="8.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.7" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.7.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Smash_Combos.Domain/Models/Combo.cs
+++ b/Smash_Combos.Domain/Models/Combo.cs
@@ -47,7 +47,7 @@ namespace Smash_Combos.Domain.Models
 
         public List<Comment> Comments { get; private set; }
 
-        public List<Report> Reports { get; private set; }
+        public List<Report> Reports { get; private set; } = new List<Report>();
 
         public int NetVote { get; private set; } = 0;
         public void VoteUp()

--- a/Smash_Combos.Domain/Models/Comment.cs
+++ b/Smash_Combos.Domain/Models/Comment.cs
@@ -18,7 +18,7 @@ namespace Smash_Combos.Domain.Models
 
         [Required]
         public string Body { get; set; }
-        public List<Report> Reports { get; private set; }
+        public List<Report> Reports { get; private set; } = new List<Report>();
         public int NetVote { get; private set; } = 0;
 
         public void VoteUp()

--- a/Smash_Combos.Domain/Models/Infraction.cs
+++ b/Smash_Combos.Domain/Models/Infraction.cs
@@ -25,9 +25,9 @@ namespace Smash_Combos.Domain.Models
         
         public DateTime? BanLiftDate { get; set; }
 
-        public int? Points { get; private set; }
+        public int? Points { get; set; }
 
-        public InfractionCategory Category { get; private set; }
+        public InfractionCategory Category { get; set; }
 
         [Required]
         public string Body { get; set; }

--- a/Smash_Combos.Domain/Models/Infraction.cs
+++ b/Smash_Combos.Domain/Models/Infraction.cs
@@ -33,5 +33,19 @@ namespace Smash_Combos.Domain.Models
         public string Body { get; set; }
 
         public DateTime DateInfracted { get; private set; }
+
+        public bool IsActiveBan()
+        {
+            if (BanDuration == null)
+                return false;
+
+            if (BanLiftDate != null && BanLiftDate < DateTime.Now)
+                return false;
+
+            if (DateInfracted.AddSeconds((double)BanDuration) > DateTime.Now)
+                return true;
+            else
+                return false;
+        }
     }
 }


### PR DESCRIPTION
Added the backend logic necessary for #23.
This should give us all we need to create, edit and delete reports/infractions.

A few notes on the Put-Method for Reports:
I figured that once it is posted, the only property in a report that should be edited is the 'Dismiss'-Property, by mods. Which is why the Request Object only has this property settable, since a report shouldn't be changed after being submitted.

Infractions, on the other hand might be edited by mods if they accidentally banned a user for too long, or if the ban reason was inappropriate and another mod/admin changes it, etc...

@Breadkenty As for the frontend, you can refer to the request objects of the API controllers as to what data you need to send in the request body. This is of course up for debate, if we want to make changes here that's easily possible, I just designed the Request-Objects in a way that makes sense to me, but let me know if I missed anything or if you want any changes!

@skittlz444 I ran into the 'issue' that handling the responses from the core in the API controllers got a bit weird, since I wanted to move as much of the logic to the core as possible. You'll see I resorted to checking for null values/introducing a 'Success'-Property to the response object. To make things easier here I thought about introducing a 'ResponseBase' class that responses inherit from, together with a 'ResponseStatus' that helps describe the result of the Core's operations a bit more. I haven't actually used the class yet, I wanted to get your opinion first. What do you think about this? Is this a good approach?

I'll get to work on moving the rest to the Core when I find some time Sunday/Monday, and when I find time I'll revamp the Combo-Methods that are already in the core as well, there's some properties in the request-objects and dto's that we don't necessarely need.